### PR TITLE
Fixes invalid html link call to action.

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,10 @@
 <hr></hr>
 
       <div class="text-center">
-	  <button type="button" class="btn btn-default panel-primary btn-lg">
-			<a href="https://www.crowdsupply.com/star-simpson/circuit-classics">Buy now on CrowdSupply</a>
-				<br />
-			<a href="https://www.crowdsupply.com/star-simpson/circuit-classics"><img src="static/crowd-supply-logo-dark-2x.png" /></a>
-	  </button>
+	  <a href="https://www.crowdsupply.com/star-simpson/circuit-classics" class="btn btn-default panel-primary btn-lg">
+			<div class="text-primary">Buy now on CrowdSupply</div>
+			<div><img src="static/crowd-supply-logo-dark-2x.png" /></div>
+	  </a>
 
       </div>
 


### PR DESCRIPTION
Nesting anchor `a` tags inside a `button` tag isn't valid html and it wasn't working in Firefox.